### PR TITLE
Fix linter errors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,16 +6,16 @@ const core = require('@actions/core');
 
 const { createProbot: probotCreate } = require('probot');
 
-function createProbot({
+function createProbot(
   overrides = {},
   defaults = {},
-  env = process.env,
-}) {
+  env = process.env
+) {
   overrides.githubToken = process.env.GITHUB_TOKEN;
-  return probotCreate({ overrides, defaults, env })
+  return probotCreate({ overrides, defaults, env });
 }
 
-async function runProbot (...handlers, { probot = createProbot }) {
+async function runProbot (handlers, { probot = createProbot }) {
   await probot.load(handlers);
 
   // Process the event


### PR DESCRIPTION
The linter complains about the previous combination of default arguments and objects.

These tweaks fix these errors, and thanks to your work here I am able to successfully use actions-adapter to use probot-settings in an action: 

https://github.com/elstudio/actions-settings/blob/v3-beta/index.js

Thank you!

Maybe I’ll take a look at the pino logging now — although that seems more daunting.